### PR TITLE
Make temp files have same names as original files

### DIFF
--- a/lib/factory_sloth/file_processor.rb
+++ b/lib/factory_sloth/file_processor.rb
@@ -21,7 +21,7 @@ module FactorySloth
 
     def process(path, dry_run:)
       code = File.read(path)
-      result = CodeMod.call(code)
+      result = CodeMod.call(path, code)
       unless dry_run
         File.write(path, result.patched_code) if result.changed?
       end

--- a/lib/factory_sloth/spec_runner.rb
+++ b/lib/factory_sloth/spec_runner.rb
@@ -1,13 +1,13 @@
-require 'tempfile'
+require 'tmpdir'
 
 module FactorySloth::SpecRunner
-  def self.call(spec_code, line: nil)
-    tempfile = Tempfile.new
-    tempfile.write(spec_code)
-    tempfile.close
-    path = [tempfile.path, line].compact.map(&:to_s).join(':')
-    result = !!system("bundle exec rspec #{path} --fail-fast 1>/dev/null 2>&1")
-    tempfile.unlink
-    result
+  def self.call(spec_path, spec_code, line: nil)
+    Dir.mktmpdir do |tmpdir|
+      path = File.join(tmpdir, spec_path)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, spec_code)
+      path_arg = [path, line].compact.map(&:to_s).join(':')
+      !!system("bundle exec rspec #{path_arg} --fail-fast 1>/dev/null 2>&1")
+    end
   end
 end

--- a/spec/factory_sloth/cli_spec.rb
+++ b/spec/factory_sloth/cli_spec.rb
@@ -1,5 +1,5 @@
 describe FactorySloth::CLI, '::call' do
-  let(:result_stub) { FactorySloth::CodeMod.new('dummy_code') }
+  let(:result_stub) { FactorySloth::CodeMod.new('a/path', 'dummy_code') }
   before { allow(result_stub).to receive(:create_calls).and_return([])}
   before { allow(result_stub).to receive(:changed_create_calls).and_return([])}
 

--- a/spec/factory_sloth/code_mod_spec.rb
+++ b/spec/factory_sloth/code_mod_spec.rb
@@ -3,7 +3,7 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'can replace create calls with build' do
     input = fixture('build_ok')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 1
     expect(result.change_count).to eq 1
@@ -13,7 +13,7 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'can replace create calls with build_stubbed' do
     input = fixture('build_stubbed_ok')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 1
     expect(result.change_count).to eq 1
@@ -23,7 +23,7 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'can keep individual create calls' do
     input = fixture('one_create_needed')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 2
     expect(result.change_count).to eq 1
@@ -34,7 +34,7 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'works with create_list' do
     input = fixture('create_list')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 1
     expect(result.change_count).to eq 1
@@ -44,7 +44,7 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'works with FactoryBot.* calls' do
     input = fixture('via_module')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 2
     expect(result.change_count).to eq 2
@@ -55,14 +55,14 @@ describe FactorySloth::CodeMod, '::call' do
 
   it 'does nothing for specs that break when individually ok changes are combined' do
     input = fixture('conflict')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).not_to be_ok
     expect(result.patched_code).to eq input
   end
 
   it 'does nothing for files without create calls' do
     input = fixture('zero_create_calls')
-    result = described_class.call(input)
+    result = described_class.call('a/path', input)
     expect(result).to be_ok
     expect(result.create_count).to eq 0
     expect(result.change_count).to eq 0

--- a/spec/factory_sloth/file_processor_spec.rb
+++ b/spec/factory_sloth/file_processor_spec.rb
@@ -1,6 +1,6 @@
 describe FactorySloth::FileProcessor, '::call' do
   let(:files) { [__FILE__] }
-  let(:result_stub) { FactorySloth::CodeMod.new('dummy_code') }
+  let(:result_stub) { FactorySloth::CodeMod.new('a/path', 'dummy_code') }
 
   it 'processes files only once by default' do
     expect(described_class).to receive(:process).and_return(result_stub)
@@ -16,7 +16,7 @@ describe FactorySloth::FileProcessor, '::call' do
       allow(result_stub).to receive(:changed_create_calls).and_return([[0, 0]] * changes)
       allow(result_stub).to receive(:ok?).and_return(ok)
       expect(File).to receive(:read).and_return :foo
-      expect(FactorySloth::CodeMod).to receive(:call).with(:foo).and_return(result_stub)
+      expect(FactorySloth::CodeMod).to receive(:call).with('x', :foo).and_return(result_stub)
       expect do
         described_class.call(files: ['x'], forced_files: ['x'], dry_run: true)
       end.to output(ok ? /\d create calls found/ : /conflict/).to_stdout


### PR DESCRIPTION
If you use RSpec's `define_derived_metadata` to set spec metadata based on some specs' `file_path`, it is important to keep a similar file path also when running the temporary files that factory_sloth creates.

The solution here passes each spec's `path` into `CodeMod` and `SpecRunner`.

For now, I have not added any new spec coverage – only changed the existing specs to pass in the extra `path` argument.